### PR TITLE
print progress to stderr instead of stdout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,16 +59,16 @@ pub fn refresh() {
             .unwrap_or((80, 24));
 
         use crossterm::ExecutableCommand;
-        let mut stdout = std::io::stdout();
+        let mut stderr = std::io::stderr();
         for (data, pos) in tqdms.iter().zip((0..height).rev()).rev() {
-            stdout.execute(crossterm::cursor::MoveTo(0, pos)).unwrap();
-            stdout
+            stderr.execute(crossterm::cursor::MoveTo(0, pos)).unwrap();
+            stderr
                 .write_fmt(format_args!("{:width$}", format!("{}", data)))
                 .unwrap();
         }
 
         use std::io::Write;
-        stdout.flush().unwrap();
+        stderr.flush().unwrap();
     }
 }
 
@@ -244,11 +244,11 @@ impl<Item, Iter: Iterator<Item = Item>> Drop for Tqdm<Item, Iter> {
                 .unwrap_or((80, 24));
 
             use crossterm::ExecutableCommand;
-            let mut stdout = std::io::stdout();
+            let mut stderr = std::io::stderr();
 
             let pos = (height - 1).checked_sub(tqdms.len() as u16).unwrap_or(0);
-            stdout.execute(crossterm::cursor::MoveTo(0, pos)).unwrap();
-            stdout
+            stderr.execute(crossterm::cursor::MoveTo(0, pos)).unwrap();
+            stderr
                 .write_fmt(format_args!(
                     "{:width$}",
                     format!("{}", self.data.lock().unwrap())
@@ -256,7 +256,7 @@ impl<Item, Iter: Iterator<Item = Item>> Drop for Tqdm<Item, Iter> {
                 .unwrap();
 
             use std::io::Write;
-            stdout.flush().unwrap();
+            stderr.flush().unwrap();
 
             // let (ncol, nrow) = display_size();
             // let top = nrow.checked_sub(tqdms.len()).unwrap_or(0);


### PR DESCRIPTION
changed all instances of `stdout` to `stderr`

I think this is the better default behavior as it's the default behavior of the `python-tqdm` [relevant source](https://github.com/tqdm/tqdm/blob/87d253f65621884c9a4020fecabc7824029e2358/tqdm/std.py#L974), [and as explained why here](https://github.com/tqdm/tqdm#module)

a follow-up PR I want to open will be to add `file` to the `config` struct so we could configure the destination of the progress bar instead. But I will wait for your approval first.

thank you for maintaining this crate 😄 