### PR TITLE
adding lazy_static to fix e0015 in edge cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ categories = ["accessibility", "command-line-utilities"]
 
 [dependencies]
 crossterm = "0.25"
+lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,11 @@ impl<Item, Iter: Iterator<Item = Item>> crate::Iter<Item> for Iter {}
 
 /* --------------------------------- STATIC --------------------------------- */
 
-static TQDM: Mutex<Vec<Arc<Mutex<Info>>>> = Mutex::new(Vec::new());
+#[macro_use]
+extern crate lazy_static;
+lazy_static! {
+    static ref TQDM: Mutex<Vec<Arc<Mutex<Info>>>> = Mutex::new(Vec::new());
+}
 
 fn terminal<W: From<u16>, H: From<u16>>() -> (W, H) {
     let (width, height) = crossterm::terminal::size().unwrap_or((80, 64));


### PR DESCRIPTION
When using this crate with [this crate](https://github.com/gobanos/cargo-aoc) for advent of code, tqdm errors out with the following error.
```Calls in statics are limited to constant functions, tuple structs and tuple variants```

It seems this is due to [this line here](https://github.com/mrlazy1708/tqdm/blob/main/src/lib.rs#L306) not using `lazy_static`

This doesnt seem to break anything in testing.