### PR TITLE
Add CI test 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --tests --jobs 1 --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: '0'
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub fn refresh() -> std::io::Result<()> {
         let lim = crossterm::terminal::size().map_or(80, |(width, _)| width as usize);
         let info: Vec<_> = tqdm.iter().filter_map(|info| info.lock().ok()).collect();
         for info in &info {
-            stderr.write_fmt(format_args!("{:<1$}", format!("{}", info), lim))?;
+            eprint!("{:<1$}", format!("{}", info), lim);
         }
 
         stderr.execute(crossterm::cursor::RestorePosition)?;
@@ -434,6 +434,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn very_slow() {
         tqdm(0..100).for_each(|_| std::thread::sleep(Duration::from_secs_f64(10.0)));
     }
@@ -449,6 +450,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn infinite() {
         for i in tqdm(0..).desc(Some("infinite")) {
             std::thread::sleep(Duration::from_secs_f64(0.1));


### PR DESCRIPTION
CI test is essential for ensuring this crate's cross-platform usability. 

This pr enables every push and pull request to be tested automatically.

Because `cargo test` doesn't capture the output produced by `stderr.write_fmt`, I changed it to `eprint!` to avoid messy test messages.

Also, I added `#[ignore]` flag to tests that cannot finish off in a limited time.