### PR TITLE
Lower MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [1.62.1, stable]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
 
 jobs:
@@ -18,15 +18,17 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Check
+        uses: actions-rs/cargo@v1
         with:
           command: check
-      - uses: actions-rs/cargo@v1
+      - name: Run Tests
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --tests --jobs 1 --all-features --no-fail-fast
         env:
-          CARGO_INCREMENTAL: '0'
+          CARGO_INCREMENTAL: "0"
 
   lint:
     runs-on: ubuntu-latest
@@ -37,11 +39,13 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1
+      - name: Format
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-      - uses: actions-rs/cargo@v1
+      - name: Clippy
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tqdm"
 edition = "2021"
 version = "0.5.0"
-rust-version = "1.70.0"
+rust-version = "1.62.1"
 
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -16,3 +16,7 @@ categories = ["accessibility", "command-line-utilities"]
 
 [dependencies]
 crossterm = "0.25"
+once_cell = "1.18.0"
+
+[build-dependencies]
+version_check = "0.9"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use version_check as rustc;
+
+fn main() {
+    if rustc::is_min_version("1.70.0").unwrap_or(false) {
+        println!("cargo:rustc-cfg=std_once_cell")
+    } else {
+        println!("cargo:rustc-cfg=extern_once_cell")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,11 @@ use std::ops::{Deref, DerefMut};
 
 use crossterm::QueueableCommand;
 
+#[cfg(extern_once_cell)]
+use once_cell::sync::OnceCell as OnceLock;
+#[cfg(std_once_cell)]
+use std::sync::OnceLock;
+
 #[cfg(test)]
 mod test;
 
@@ -305,7 +310,7 @@ impl<Item, Iter: Iterator<Item = Item>> crate::Iter<Item> for Iter {}
 /* --------------------------------- STATIC --------------------------------- */
 
 static ID: sync::atomic::AtomicUsize = sync::atomic::AtomicUsize::new(0);
-static BAR: sync::OnceLock<sync::Mutex<collections::HashMap<usize, Info>>> = sync::OnceLock::new();
+static BAR: OnceLock<sync::Mutex<collections::HashMap<usize, Info>>> = OnceLock::new();
 
 fn size<T: From<u16>>() -> (T, T) {
     let (width, height) = crossterm::terminal::size().unwrap_or((80, 64));


### PR DESCRIPTION
- Use build script and cfg to choose between std/once_cell primitives
- Add CI tests to ensure lib works on both 1.63 and 1.70 rustc versions