### PR TITLE
Implemented tqdm_total to Enable Crate User Setting a Pbar Length

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -8,12 +8,14 @@
 //!
 //! Other styles are open for [contribution](https://github.com/mrlazy1708/tqdm/issues/1).
 
+use std::fmt::Display;
+
 pub enum Style {
     ASCII,
     Block,
     Balloon,
     Pacman,
-    Custom(String)
+    Custom(String),
 }
 
 impl Default for Style {
@@ -22,14 +24,15 @@ impl Default for Style {
     }
 }
 
-impl ToString for Style {
-    fn to_string(&self) -> String {
-        String::from(match self {
+impl Display for Style {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = String::from(match self {
             Style::ASCII => "0123456789#",
             Style::Block => " ▏▎▍▌▋▊▉█",
             Style::Balloon => ".oO@*",
             Style::Pacman => "C-",
             Style::Custom(n) => &n[..],
-        })
+        });
+        write!(f, "{}", str)
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -51,6 +51,22 @@ fn breaking() {
     }
 }
 
+#[test]
+fn given_total_length() {
+    // Should show a total at first, then switch to no pbar
+    for _ in tqdm_total(0..10, 5) {
+        thread::sleep(Duration::from_millis(250));
+    }
+    // Fills up as far as the iterator goes, then stops
+    for _ in tqdm_total(0..10, 20) {
+        thread::sleep(Duration::from_millis(250));
+    }
+    // Shows no pbar at all
+    for _ in tqdm_total(0..10, 0) {
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
 /* -------------------------------------------------------------------------- */
 /*                                  MULTI-BAR                                 */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Closes #20.

Unfortunately, Rust does not allow for overloading of functions via varying parameter lengths. I've added a function `tqdm_total` that sets a user-given pbar length. As this opens to the door to `Info.total` being smaller than the number of iterations, I've adjusted the crate behavior to be similar to the python tqdm crate. Should the number of iterations be higher than foreseen by the user, the progress bar disappears.

I also ran `cargo fmt` across the project and changed `impl ToString` into `impl Display` to keep in line with best practices.