### PR TITLE
Bump `crossterm` dependency to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["accessibility", "command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0"
-crossterm = "0.25"
+crossterm = "0.29"
 
 [dependencies.once_cell]
 version = "1.18"


### PR DESCRIPTION
Use latest `cossterm`.


### Related
https://github.com/EricLBuehler/mistral.rs/pull/1911