### PR TITLE
Increase MSRV to 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,25 @@ on:
   pull_request:
 
 jobs:
+  msrv:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: |
+            cargo-hack
+            cargo-minimal-versions
+          fallback: none
+      - run: cargo minimal-versions check --rust-version --workspace --all-targets --feature-powerset
+
   test:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tqdm"
 edition = "2021"
 version = "0.8.0"
-rust-version = "1.60"
+rust-version = "1.75"
 
 readme = "README.md"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
It seems https://github.com/mrlazy1708/tqdm/pull/28 bumped the MSRV to 1.75, declare this properly in the Cargo manifest and add some CI to prevent regressions