### PR TITLE
ci: fix Windows MSRV command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,7 @@ jobs:
             cargo-hack
             cargo-minimal-versions
           fallback: none
-      - run: |
-          cargo minimal-versions check \
-            --rust-version \
-            --workspace \
-            --all-targets \
-            --feature-powerset
+      - run: cargo minimal-versions check --rust-version --workspace --all-targets --feature-powerset
 
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,30 @@ on:
   pull_request:
 
 jobs:
+  msrv:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: |
+            cargo-hack
+            cargo-minimal-versions
+          fallback: none
+      - run: |
+          cargo minimal-versions check \
+            --rust-version \
+            --workspace \
+            --all-targets \
+            --feature-powerset
+
   test:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tqdm"
 edition = "2021"
 version = "0.8.0"
-rust-version = "1.60"
+rust-version = "1.75"
 
 readme = "README.md"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Includes the MSRV 1.75 update from #30 and fixes its Windows CI failure.

The MSRV job used Bash-style backslash continuations, which PowerShell parses as an invalid `--rust-version` expression. This uses one shell-independent `cargo minimal-versions` command.

Validation: `cargo test --tests --verbose`.