### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# tqdm <img alt="Crates.io Version" src="https://img.shields.io/crates/v/tqdm"> <img alt="Crates.io Downloads" src="https://img.shields.io/crates/d/tqdm"> <img alt="Crates.io MSRV" src="https://img.shields.io/crates/msrv/tqdm">
+# tqdm
+
+[![crates.io](https://img.shields.io/crates/v/tqdm.svg)](https://crates.io/crates/tqdm)
+[![downloads](https://img.shields.io/crates/d/tqdm.svg)](https://crates.io/crates/tqdm)
+[![docs.rs](https://docs.rs/tqdm/badge.svg)](https://docs.rs/tqdm)
+[![build status](https://github.com/mrlazy1708/tqdm/actions/workflows/ci.yml/badge.svg)](https://github.com/mrlazy1708/tqdm/actions)
+[![dependency status](https://deps.rs/repo/github/mrlazy1708/tqdm/status.svg)](https://deps.rs/repo/github/mrlazy1708/tqdm)
 
 >
 > Instantly make your loops show a smart progress meter - just wrap any iterable with tqdm(iterable), and you're done!


### PR DESCRIPTION
- Make the crates.io version and download badges clickable.
- Add badges for docs.rs, CI, and dependency status.
- Remove the MSRV badge so the MSRV is defined in a single place: the `rust-version` field in `Cargo.toml`. This value is now displayed on crates.io so it's unnecessary in the README.